### PR TITLE
Stop forcing exposure age calculator to summarize; fix set/list error…

### DIFF
--- a/django-app/iced/base/views.py
+++ b/django-app/iced/base/views.py
@@ -50,7 +50,7 @@ context_base = {
 def _call_calculation(calculation_name: str, input: str):
     calculation = Calculation.get_calculation_by_name(calculation_name)
     variables = json.loads(calculation.variable_json)
-    variables["summary"] = "yes"
+    variables["summary"] = "no"
     variables["text_block"] = input
     run_calculation_endpoint = (
         f"{settings.BASE_URL}/api/calculations/run/" + calculation_name
@@ -744,7 +744,8 @@ def site(request, application_name, site_name):
             cl36_str, "Cl36_input_v3")
 
     else:
-        publications = []
+        # publications = []
+        publications = set() # this has to be a set so it can be unioned later
         n_tables = {}
         cl36_str = ""
         v3_str = ""


### PR DESCRIPTION
This stops forcing the exposure age calculator to use the 'summarize' option. It also fixes an error in publications lookup handling in the 'sites' view that crashed when sites had 'cores' but no 'samples. 
